### PR TITLE
miscellaneous patches

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ project(ENVYTOOLS C)
 cmake_minimum_required(VERSION 2.6)
 enable_testing()
 
-SET(CMAKE_C_FLAGS "-g -O2 -Wall")
+SET(CMAKE_C_FLAGS "-Wall")
 
 include_directories(include)
 

--- a/afuc/afuc.h
+++ b/afuc/afuc.h
@@ -102,6 +102,7 @@ typedef enum {
 	OPC_RET    = 0x34,  /* return */
 	OPC_CALL   = 0x35,  /* "function" call */
 	OPC_WIN    = 0x36,  /* wait for input (ie. wait for WPTR to advance) */
+	OPC_PREEMPTLEAVE6 = 0x38,  /* try to leave preemption */
 } afuc_opc;
 
 

--- a/afuc/asm.c
+++ b/afuc/asm.c
@@ -253,6 +253,10 @@ static void emit_instructions(int outfd)
 			opc = OPC_CALL;
 			instr.call.uoff = resolve_label(ai->label);
 			break;
+		case T_OP_PREEMPTLEAVE:
+			opc = OPC_PREEMPTLEAVE6;
+			instr.call.uoff = resolve_label(ai->label);
+			break;
 		case T_OP_JUMP:
 			/* encode jump as: brne $00, b0, #label */
 			opc = OPC_BRNEB;

--- a/afuc/disasm.c
+++ b/afuc/disasm.c
@@ -339,6 +339,10 @@ static void disasm(uint32_t *buf, int sizedwords)
 		case OPC_BREQB:
 			label_idx(i + instr->br.ioff, true);
 			break;
+		case OPC_PREEMPTLEAVE6:
+			if (gpuver >= 6)
+				label_idx(instr->call.uoff, true);
+			break;
 		case OPC_CALL:
 			fxn_idx(instr->call.uoff, true);
 			break;
@@ -668,6 +672,13 @@ static void disasm(uint32_t *buf, int sizedwords)
 			printf("waitin");
 			if (verbose && instr->waitin.pad)
 				printerr("  (pad=%x)", instr->waitin.pad);
+			break;
+		case OPC_PREEMPTLEAVE6:
+			if (gpuver < 6) {
+				printf("[%08x]  ; op38", instrs[i]);
+			}
+			printf("preemptleave #");
+			printlbl("%s", label_name(instr->call.uoff, true));
 			break;
 		default:
 			printerr("[%08x]", instrs[i]);

--- a/afuc/lexer.l
+++ b/afuc/lexer.l
@@ -77,6 +77,7 @@ extern YYSTYPE yylval;
 "call"                            return TOKEN(T_OP_CALL);
 "jump"                            return TOKEN(T_OP_JUMP);
 "waitin"                          return TOKEN(T_OP_WAITIN);
+"preemptleave"			  return TOKEN(T_OP_PREEMPTLEAVE);
 "<<"                              return TOKEN(T_LSHIFT);
 "(rep)"                           return TOKEN(T_REP);
 

--- a/afuc/parser.y
+++ b/afuc/parser.y
@@ -163,6 +163,7 @@ static void print_token(FILE *file, int type, YYSTYPE value)
 %token <tok> T_OP_CALL
 %token <tok> T_OP_JUMP
 %token <tok> T_OP_WAITIN
+%token <tok> T_OP_PREEMPTLEAVE
 %token <tok> T_LSHIFT
 %token <tok> T_REP
 
@@ -244,6 +245,7 @@ branch_instr:      branch_op reg ',' T_BIT ',' T_LABEL_REF     { src1($2); bit($
 |                  branch_op reg ',' immediate ',' T_LABEL_REF { src1($2); immed($4); label($6); }
 
 other_instr:       T_OP_CALL T_LABEL_REF { new_instr($1); label($2); }
+|                  T_OP_PREEMPTLEAVE T_LABEL_REF { new_instr($1); label($2); }
 |                  T_OP_RET              { new_instr($1); }
 |                  T_OP_JUMP T_LABEL_REF { new_instr($1); label($2); }
 |                  T_OP_WAITIN           { new_instr($1); }

--- a/cffdump/cffdump.c
+++ b/cffdump/cffdump.c
@@ -66,6 +66,9 @@ static void print_usage(const char *name)
 	printf("    --no-color        - disable colorized output (default for non-console\n");
 	printf("                        output)\n");
 	printf("    --color           - enable colorized output (default for tty output)\n");
+	printf("    --no-pager        - disable pager (default for non-console\n");
+	printf("                        output)\n");
+	printf("    --pager           - enable pager (default for tty output)\n");
 	printf("    --summary         - don't show individual register writes, but just show\n");
 	printf("                        register values on draws\n");
 	printf("    --allregs         - show all registers (including ones not written since\n");
@@ -120,6 +123,18 @@ int main(int argc, char **argv)
 
 		if (!strcmp(argv[n], "--color")) {
 			options.color = true;
+			n++;
+			continue;
+		}
+
+		if (!strcmp(argv[n], "--no-pager")) {
+			interactive = 0;
+			n++;
+			continue;
+		}
+
+		if (!strcmp(argv[n], "--pager")) {
+			interactive = 1;
 			n++;
 			continue;
 		}


### PR DESCRIPTION
This is a collection of patches I've been carrying around for a while and should probably upstream in case they're useful for other people. The first two were useful for debugging crashes in `cffdump`, the last is a missing opcode in afuc which is needed to properly modify and re-assemble the firmware (although it only really affects preemption).