### PR TITLE
afuc: Add msb instruction

### DIFF
--- a/afuc/afuc.h
+++ b/afuc/afuc.h
@@ -51,7 +51,7 @@ typedef enum {
 	OPC_AND    = 0x05,  /* AND immediate */
 	OPC_OR     = 0x06,  /* OR immediate */
 	OPC_XOR    = 0x07,  /* XOR immediate */
-	OPC_NOT    = 0x08,  /* bitwise not of immed (src ignored */
+	OPC_NOT    = 0x08,  /* bitwise not of immed (src1 ignored) */
 	OPC_SHL    = 0x09,  /* shift-left immediate */
 	OPC_USHR   = 0x0a,  /* unsigned shift right by immediate */
 	OPC_ISHR   = 0x0b,  /* signed shift right by immediate */
@@ -61,6 +61,12 @@ typedef enum {
 	OPC_MAX    = 0x0f,
 	OPC_CMP    = 0x10,  /* compare src to immed */
 	OPC_MOVI   = 0x11,  /* move immediate */
+
+	/* Return the most-significant bit of src2, or 0 if src2 == 0 (the
+	 * same as if src2 == 1). src1 is ignored. Note that this overlaps
+	 * with STORE6, so it can only be used with the two-source encoding.
+	 */
+	OPC_MSB    = 0x14,
 
 
 	OPC_ALU    = 0x13,  /* ALU instruction with two src registers */

--- a/afuc/asm.c
+++ b/afuc/asm.c
@@ -107,6 +107,7 @@ static afuc_opc tok2alu(int tok)
 	case T_OP_MIN:   return OPC_MIN;
 	case T_OP_MAX:   return OPC_MAX;
 	case T_OP_CMP:   return OPC_CMP;
+	case T_OP_MSB:   return OPC_MSB;
 	default:
 		assert(0);
 		return -1;
@@ -164,7 +165,10 @@ static void emit_instructions(int outfd)
 		case T_OP_MIN:
 		case T_OP_MAX:
 		case T_OP_CMP:
+		case T_OP_MSB:
 			if (ai->has_immed) {
+				/* MSB overlaps with STORE */
+				assert(ai->tok != T_OP_MSB);
 				opc = tok2alu(ai->tok);
 				instr.alui.dst = ai->dst;
 				instr.alui.src = ai->src1;

--- a/afuc/disasm.c
+++ b/afuc/disasm.c
@@ -149,6 +149,8 @@ static void print_alu_name(afuc_opc opc, uint32_t instr)
 		printf("max ");
 	} else if (opc == OPC_CMP) {
 		printf("cmp ");
+	} else if (opc == OPC_MSB) {
+		printf("msb ");
 	} else {
 		printerr("[%08x]", instr);
 		printf("  ; alu%02x ", opc);
@@ -502,7 +504,7 @@ static void disasm(uint32_t *buf, int sizedwords)
 		case OPC_ALU: {
 			bool src1 = true;
 
-			if (instr->alu.alu == OPC_NOT)
+			if (instr->alu.alu == OPC_NOT || instr->alu.alu == OPC_MSB)
 				src1 = false;
 
 			if (instr->alu.pad)

--- a/afuc/lexer.l
+++ b/afuc/lexer.l
@@ -66,6 +66,7 @@ extern YYSTYPE yylval;
 "min"                             return TOKEN(T_OP_MIN);
 "max"                             return TOKEN(T_OP_MAX);
 "cmp"                             return TOKEN(T_OP_CMP);
+"msb"                             return TOKEN(T_OP_MSB);
 "mov"                             return TOKEN(T_OP_MOV);
 "cwrite"                          return TOKEN(T_OP_CWRITE);
 "cread"                           return TOKEN(T_OP_CREAD);

--- a/afuc/parser.y
+++ b/afuc/parser.y
@@ -152,6 +152,7 @@ static void print_token(FILE *file, int type, YYSTYPE value)
 %token <tok> T_OP_MIN
 %token <tok> T_OP_MAX
 %token <tok> T_OP_CMP
+%token <tok> T_OP_MSB
 %token <tok> T_OP_MOV
 %token <tok> T_OP_CWRITE
 %token <tok> T_OP_CREAD
@@ -189,9 +190,14 @@ instr_or_label:    instr_r
 instr_r:           alu_instr
 |                  config_instr
 
-/* need to special case not (since src) and mov (single src, plus possibly a shift)
+/* need to special case:
+ * - not (single src, possibly an immediate)
+ * - msb (single src, must be reg)
+ * - mov (single src, plus possibly a shift)
  * from the other ALU instructions:
  */
+
+alu_msb_instr:     T_OP_MSB reg ',' reg        { new_instr($1); dst($2); src2($4); }
 
 alu_not_instr:     T_OP_NOT reg ',' reg        { new_instr($1); dst($2); src2($4); }
 |                  T_OP_NOT reg ',' immediate  { new_instr($1); dst($2); immed($4); }
@@ -226,6 +232,7 @@ alu_2src_instr:    alu_2src_op reg ',' reg ',' reg { dst($2); src1($4); src2($6)
 |                  alu_2src_op reg ',' reg ',' immediate { dst($2); src1($4); immed($6); }
 
 alu_instr:         alu_2src_instr
+|                  alu_msb_instr
 |                  alu_not_instr
 |                  alu_mov_instr
 


### PR DESCRIPTION
It's used in a630_sqe.fw for finding the next active draw state. I just got around to hacking the fw to confirm what it does though.