### PR TITLE
rnn: low/high bits to typeinfo

### DIFF
--- a/cffdump/cffdec.c
+++ b/cffdump/cffdec.c
@@ -817,7 +817,7 @@ dump_register_val(uint32_t regbase, uint32_t dword, int level)
 
 	if (info && info->typeinfo) {
 		uint64_t gpuaddr = 0;
-		char *decoded = rnndec_decodeval(rnn->vc, info->typeinfo, dword, info->width);
+		char *decoded = rnndec_decodeval(rnn->vc, info->typeinfo, dword);
 		printf("%s%s: %s", levels[level], info->name, decoded);
 
 		/* Try and figure out if we are looking at a gpuaddr.. this
@@ -919,7 +919,7 @@ dump_domain(uint32_t *dwords, uint32_t sizedwords, int level,
 		char *decoded;
 		if (!(info && info->typeinfo))
 			break;
-		decoded = rnndec_decodeval(rnn->vc, info->typeinfo, dwords[i], info->width);
+		decoded = rnndec_decodeval(rnn->vc, info->typeinfo, dwords[i]);
 		printf("%s%s\n", levels[level], decoded);
 		free(decoded);
 		free(info->name);

--- a/cffdump/crashdec.c
+++ b/cffdump/crashdec.c
@@ -411,7 +411,7 @@ dump_register(struct rnn *rnn, uint32_t offset, uint32_t value)
 {
 	struct rnndecaddrinfo *info = rnn_reginfo(rnn, offset);
 	if (info && info->typeinfo) {
-		char *decoded = rnndec_decodeval(rnn->vc, info->typeinfo, value, info->width);
+		char *decoded = rnndec_decodeval(rnn->vc, info->typeinfo, value);
 		printf("%s: %s\n", info->name, decoded);
 	} else if (info) {
 		printf("%s: %08x\n", info->name, value);

--- a/cffdump/script.c
+++ b/cffdump/script.c
@@ -351,8 +351,8 @@ static int l_rnn_reg_meta_index(lua_State *L)
 		if (!strcmp(name, bf->name)) {
 			uint32_t regval = rnn_val(rnndoff->rnn, rnndoff->offset);
 
-			regval &= bf->mask;
-			regval >>= bf->low;
+			regval &= typeinfo_mask(&bf->typeinfo);
+			regval >>= bf->typeinfo.low;
 			regval <<= bf->typeinfo.shr;
 
 			DBG("name=%s, info=%p, subelemsnum=%d, type=%d, regval=%x",
@@ -375,7 +375,7 @@ static int l_rnn_reg_meta_tostring(lua_State *L)
 	char *decoded;
 	if (info && info->typeinfo) {
 		decoded = rnndec_decodeval(rnndoff->rnn->vc,
-				info->typeinfo, regval, info->width);
+				info->typeinfo, regval);
 	} else {
 		asprintf(&decoded, "%08x", regval);
 	}
@@ -493,7 +493,7 @@ static int l_rnn_regval(lua_State *L)
 	struct rnndecaddrinfo *info = rnn_reginfo(rnn, regbase);
 	char *decoded;
 	if (info && info->typeinfo) {
-		decoded = rnndec_decodeval(rnn->vc, info->typeinfo, regval, info->width);
+		decoded = rnndec_decodeval(rnn->vc, info->typeinfo, regval);
 	} else {
 		asprintf(&decoded, "%08x", regval);
 	}

--- a/include/rnn.h
+++ b/include/rnn.h
@@ -136,10 +136,18 @@ struct rnntypeinfo {
 	struct rnnvalue **vals;
 	int valsnum;
 	int valsmax;
-	int shr;
+	int shr, low, high;
 	uint64_t min, max, align, radix;
 	int minvalid, maxvalid, alignvalid, radixvalid;
 };
+
+static inline uint64_t typeinfo_mask(struct rnntypeinfo *ti)
+{
+	if (ti->high == 63)
+		return -(1ULL << ti->low);
+	else
+		return (1ULL << (ti->high + 1)) - (1ULL << ti->low);
+}
 
 struct rnnbitset {
 	char *name;
@@ -155,8 +163,6 @@ struct rnnbitset {
 
 struct rnnbitfield {
 	char *name;
-	int low, high;
-	uint64_t mask;
 	struct rnnvarinfo varinfo;
 	struct rnntypeinfo typeinfo;
 	char *fullname;

--- a/include/rnndec.h
+++ b/include/rnndec.h
@@ -51,7 +51,7 @@ struct rnndeccontext *rnndec_newcontext(struct rnndb *db);
 int rnndec_varadd(struct rnndeccontext *ctx, char *varset, char *variant);
 int rnndec_varmatch(struct rnndeccontext *ctx, struct rnnvarinfo *vi);
 char *rnndec_decode_enum(struct rnndeccontext *ctx, const char *enumname, uint64_t enumval);
-char *rnndec_decodeval(struct rnndeccontext *ctx, struct rnntypeinfo *ti, uint64_t value, int width);
+char *rnndec_decodeval(struct rnndeccontext *ctx, struct rnntypeinfo *ti, uint64_t value);
 int rnndec_checkaddr(struct rnndeccontext *ctx, struct rnndomain *domain, uint64_t addr, int write);
 struct rnndecaddrinfo *rnndec_decodeaddr(struct rnndeccontext *ctx, struct rnndomain *domain, uint64_t addr, int write);
 uint64_t rnndec_decodereg(struct rnndeccontext *ctx, struct rnndomain *domain, const char *name);

--- a/rnn/dedma.c
+++ b/rnn/dedma.c
@@ -131,8 +131,7 @@ pretty_method(struct state *s, struct ent *e, uint32_t x)
 		ai = rnndec_decodeaddr(obj->ctx, s->dom, dma->addr, true);
 
 		dec_addr = ai->name;
-		dec_val = rnndec_decodeval(obj->ctx, ai->typeinfo, x,
-					   ai->width);
+		dec_val = rnndec_decodeval(obj->ctx, ai->typeinfo, x);
 
 		free(ai);
 	} else {

--- a/rnn/demmio.c
+++ b/rnn/demmio.c
@@ -377,7 +377,7 @@ int main(int argc, char **argv) {
 						cc->crx1 = value & 0xff;
 					} else if (addr == 0x6013d5) {
 						struct rnndecaddrinfo *ai = rnndec_decodeaddr(cc->ctx, crdom, cc->crx0, line[0] == 'W');
-						char *decoded_val = rnndec_decodeval(cc->ctx, ai->typeinfo, value, ai->width);
+						char *decoded_val = rnndec_decodeval(cc->ctx, ai->typeinfo, value);
 						printf ("[%d] %lf CRTC0 %c     0x%02x       0x%02"PRIx64" %s %s %s\n", cci, timestamp, line[0], cc->crx0, value, ai->name, line[0]=='W'?"<=":"=>", decoded_val);
 						free(ai->name);
 						free(ai);
@@ -385,7 +385,7 @@ int main(int argc, char **argv) {
 						skip = 1;
 					} else if (addr == 0x6033d5) {
 						struct rnndecaddrinfo *ai = rnndec_decodeaddr(cc->ctx, crdom, cc->crx1, line[0] == 'W');
-						char *decoded_val = rnndec_decodeval(cc->ctx, ai->typeinfo, value, ai->width);
+						char *decoded_val = rnndec_decodeval(cc->ctx, ai->typeinfo, value);
 						printf ("[%d] %lf CRTC1 %c     0x%02x       0x%02"PRIx64" %s %s %s\n", cci, timestamp, line[0], cc->crx1, value, ai->name, line[0]=='W'?"<=":"=>", decoded_val);
 						free(ai->name);
 						free(ai);
@@ -462,7 +462,7 @@ int main(int argc, char **argv) {
 							int cnt;
 							for (b = 0; b < 4; b++) {
 								struct rnndecaddrinfo *ai = rnndec_decodeaddr(cc->ctx, mmiodom, addr+b, line[0] == 'W');
-								char *decoded_val = rnndec_decodeval(cc->ctx, ai->typeinfo, value >> b * 8 & 0xff, ai->width);
+								char *decoded_val = rnndec_decodeval(cc->ctx, ai->typeinfo, value >> b * 8 & 0xff);
 								if (b == 0) {
 									printf ("[%d] %lf MMIO%d %c 0x%06"PRIx64" 0x%08"PRIx64" %n%s %s %s\n", cci, timestamp, width, line[0], addr, value, &cnt, ai->name, line[0]=='W'?"<=":"=>", decoded_val);
 								} else {
@@ -476,7 +476,7 @@ int main(int argc, char **argv) {
 								free(decoded_val);
 							}
 						} else {
-							char *decoded_val = rnndec_decodeval(cc->ctx, ai->typeinfo, value, ai->width);
+							char *decoded_val = rnndec_decodeval(cc->ctx, ai->typeinfo, value);
 							printf ("[%d] %lf MMIO%d %c 0x%06"PRIx64" 0x%08"PRIx64" %s %s %s\n", cci, timestamp, width, line[0], addr, value, ai->name, line[0]=='W'?"<=":"=>", decoded_val);
 							free(ai->name);
 							free(ai);

--- a/rnn/demsm.c
+++ b/rnn/demsm.c
@@ -158,7 +158,7 @@ static void printval(struct rnndeccontext *ctx, uint32_t addr, uint32_t val, uin
 	if (d && d->dom) {
 		uint32_t off = addr - d->base;
 		struct rnndecaddrinfo *ai = rnndec_decodeaddr(ctx, d->dom, off >> d->shift, op);
-		char *decoded_val = rnndec_decodeval(ctx, ai->typeinfo, val, ai->width);
+		char *decoded_val = rnndec_decodeval(ctx, ai->typeinfo, val);
 		if (origaddr != addr) {
 			printf("%08x:!%9s:%-30s %s", val, d->dom->name, ai->name, decoded_val);
 		} else {

--- a/rnn/lookup.c
+++ b/rnn/lookup.c
@@ -149,7 +149,7 @@ int main(int argc, char **argv) {
 		if (dom) {
 			struct rnndecaddrinfo *info = rnndec_decodeaddr(vc, dom, reg, 0);
 			if (info && info->typeinfo)
-				printf ("%s => %s\n", info->name, rnndec_decodeval(vc, info->typeinfo, val, info->width));
+				printf ("%s => %s\n", info->name, rnndec_decodeval(vc, info->typeinfo, val));
 			else if (info)
 				printf ("%s\n", info->name);
 			else


### PR DESCRIPTION
This allows specific low/high/pos bits directly in `<reg32/>` in xml, to
avoid creating `<bitfields/>` for registers with only one field.