### PR TITLE
various cffdump improvements for multi-draw indirect

### DIFF
--- a/cffdump/cffdec.c
+++ b/cffdump/cffdec.c
@@ -920,7 +920,21 @@ dump_domain(uint32_t *dwords, uint32_t sizedwords, int level,
 		if (!(info && info->typeinfo))
 			break;
 		decoded = rnndec_decodeval(rnn->vc, info->typeinfo, dwords[i]);
-		printf("%s%s\n", levels[level], decoded);
+		/* Unlike the register printing path, we don't print the name
+		 * of the register, so if it doesn't contain other named
+		 * things (i.e. it isn't a bitset) then print the register
+		 * name as if it's a bitset with a single entry. This avoids
+		 * having to create a dummy register with a single entry to
+		 * get a name in the decoding.
+		 */
+		if (info->typeinfo->type == RNN_TTYPE_BITSET ||
+		    info->typeinfo->type == RNN_TTYPE_INLINE_BITSET) {
+			printf("%s%s\n", levels[level], decoded);
+		} else {
+			printf("%s{ %s%s%s = %s }\n", levels[level],
+					rnn->vc->colors->rname, info->name,
+					rnn->vc->colors->reset, decoded);
+		}
 		free(decoded);
 		free(info->name);
 		free(info);

--- a/cffdump/cffdec.c
+++ b/cffdump/cffdec.c
@@ -919,7 +919,12 @@ dump_domain(uint32_t *dwords, uint32_t sizedwords, int level,
 		char *decoded;
 		if (!(info && info->typeinfo))
 			break;
-		decoded = rnndec_decodeval(rnn->vc, info->typeinfo, dwords[i]);
+		uint64_t value = dwords[i];
+		if (info->typeinfo->high >= 32 && i < sizedwords - 1) {
+			value |= (uint64_t) dwords[i + 1] << 32;
+			i++; /* skip the next dword since we're printing it now */
+		}
+		decoded = rnndec_decodeval(rnn->vc, info->typeinfo, value);
 		/* Unlike the register printing path, we don't print the name
 		 * of the register, so if it doesn't contain other named
 		 * things (i.e. it isn't a bitset) then print the register

--- a/include/rnn.h
+++ b/include/rnn.h
@@ -138,6 +138,7 @@ struct rnntypeinfo {
 	int valsmax;
 	int shr, low, high;
 	uint64_t min, max, align, radix;
+	int addvariant;
 	int minvalid, maxvalid, alignvalid, radixvalid;
 };
 

--- a/rnn/rnn.c
+++ b/rnn/rnn.c
@@ -198,6 +198,8 @@ static int trytypeattr (struct rnndb *db, char *file, xmlNode *node, xmlAttr *at
 	} else if (!strcmp(attr->name, "high")) {
 		ti->high = getnumattrib(db, file, node->line, attr);
 		return 1;
+	} else if (!strcmp(attr->name, "addvariant")) {
+		ti->addvariant = getboolattrib(db, file, node->line, attr);
 	}
 	return 0;
 }
@@ -943,6 +945,7 @@ static void copytypeinfo (struct rnntypeinfo *dst, struct rnntypeinfo *src, char
 	dst->min = src->min;
 	dst->max = src->max;
 	dst->align = src->align;
+	dst->addvariant = src->addvariant;
 	for (i = 0; i < src->valsnum; i++)
 		ADDARRAY(dst->vals, copyvalue(src->vals[i], file));
 	for (i = 0; i < src->bitfieldsnum; i++)
@@ -1186,6 +1189,10 @@ static void preptypeinfo(struct rnndb *db, struct rnntypeinfo *ti, char *prefix,
 	} else {
 		ti->name = "hex";
 		ti->type = RNN_TTYPE_HEX;
+	}
+	if (ti->addvariant && ti->type != RNN_TTYPE_ENUM) {
+		fprintf (stderr, "%s: addvariant specified on non-enum type %s\n", prefix, ti->name);
+		db->estatus = 1;
 	}
 	for (i = 0; i < ti->bitfieldsnum; i++)
 		prepbitfield(db,  ti->bitfields[i], prefix, vi);


### PR DESCRIPTION
The current approach of marking up `CP_DRAW_INDIRECT_MULTI` isn't going to work with the indirect count variants. The `addvariants` magic lets us make the opcode a variant we can match on, with no cffdump-specific code. While here, I also added some things that should make it easier to create less verbose packet definitions, that I'll take advantage of in the Mesa MR.